### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         token: ${{secrets.TOKEN}} 
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@3.04
+      uses: elgohr/Publish-Docker-Github-Action@v5
     
       with:
         name: pon0mar/homework3


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore